### PR TITLE
[BE/FEAT] 비동기 STT 처리 및 Gemini 일괄 번역 파이프라인 구축 (Kafka + WebSocket)

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,1 @@
+GEMINI_API_KEY="본인의 api키 입력"

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -77,6 +77,7 @@ services:
       - KAFKA_BOOTSTRAP_SERVERS=kafka:9092 # Kafka 서비스 이름:포트
       - REDIS_HOST=redis # Redis는 히스토리 저장용으로 남겨둠 (아래 Redis 서비스 필요)
       - REDIS_PORT=6379
+      - GEMINI_API_KEY=${GEMINI_API_KEY} 
       - REDIS_DB_WS_MESSAGES=3
       - PYTHONUNBUFFERED=1
     depends_on: # Redis가 먼저 실행되어야 함

--- a/backend/services/stt-processor/requirements.txt
+++ b/backend/services/stt-processor/requirements.txt
@@ -8,4 +8,5 @@ python-dotenv      # 환경 변수 관리 (선택 사항)
 kafka-python
 redis         # Python Redis 클라이언트
 pydub         # 오디오 분할/처리용
+google-generativeai
 # websockets 라이브러리는 uvicorn[standard]에 포함될 수 있음

--- a/backend/services/stt-processor/src/consumer.py
+++ b/backend/services/stt-processor/src/consumer.py
@@ -76,113 +76,140 @@ def send_update_to_kafka(task_id: str, status: str, progress: int = None, data: 
 def process_stt_request(task_id: str, wav_file_path: str, language: str):
     """STT 요청 처리: 오디오 분할, 청크별 STT, 결과 Kafka 전송"""
     logger.info(f"[Task {task_id}] Processing started for: {wav_file_path}")
-    send_update_to_kafka(task_id, "PROCESSING", progress=0)
+    # 초기 상태 업데이트: 작업 시작 알림
+    send_update_to_kafka(task_id, "PROCESSING", progress=0, data={"message": "Audio processing initiated."})
 
     base_dir = Path(wav_file_path).parent
-    chunk_output_dir = base_dir / f"chunks_{task_id}"
+    # 작업별 고유한 청크 디렉토리 이름 생성 (충돌 방지)
+    chunk_output_dir_name = f"chunks_{task_id}"
+    chunk_output_dir = base_dir / chunk_output_dir_name
     try:
         chunk_output_dir.mkdir(exist_ok=True, parents=True)
+        logger.info(f"[Task {task_id}] Created chunk directory: {chunk_output_dir}")
     except OSError as e:
         logger.error(f"[Task {task_id}] Failed to create chunk directory {chunk_output_dir}: {e}")
         send_update_to_kafka(task_id, "FAILED", error=f"Cannot create temporary directory: {e}")
-        return # 작업 실패
+        return
 
-    all_segments_combined = [] # 전체 결과 저장용 (선택 사항)
+    all_segments_combined = [] # 모든 STT 세그먼트를 축적할 리스트
     has_chunk_error = False
 
     try:
-        # 1. 오디오 로드 및 분할
-        logger.info(f"[Task {task_id}] Loading audio file...")
+        logger.info(f"[Task {task_id}] Loading audio file: {wav_file_path}")
         audio = AudioSegment.from_wav(wav_file_path)
         total_duration_ms = len(audio)
         logger.info(f"[Task {task_id}] Audio loaded. Duration: {total_duration_ms / 1000:.2f}s")
-        send_update_to_kafka(task_id, "PROCESSING", progress=5, data={"message": "Audio loaded, splitting..."})
+        send_update_to_kafka(task_id, "PROCESSING", progress=5, data={"message": "Audio loaded, splitting into chunks..."})
 
-        chunk_length_ms = 60 * 1000
+        chunk_length_ms = 60 * 1000  # 60초 단위로 청크 분할
         chunks = [audio[i:min(i + chunk_length_ms, total_duration_ms)] for i in range(0, total_duration_ms, chunk_length_ms)]
         total_chunks = len(chunks)
 
-        if not chunks:
-            logger.warning(f"[Task {task_id}] No chunks generated.")
-            send_update_to_kafka(task_id, "COMPLETED", progress=100, data=[])
+        if not chunks: # 청크가 생성되지 않은 경우 (예: 매우 짧은 오디오)
+            logger.warning(f"[Task {task_id}] No audio chunks were generated from the input file.")
+            # STT 작업은 완료되었지만, 번역할 내용이 없음을 API에 알림
+            send_update_to_kafka(task_id, "STT_COMPLETED_ALL_SEGMENTS", progress=95, data=[])
             return
 
-        logger.info(f"[Task {task_id}] Split into {total_chunks} chunks.")
+        logger.info(f"[Task {task_id}] Audio split into {total_chunks} chunks.")
         send_update_to_kafka(task_id, "PROCESSING", progress=10, data={"message": f"Split into {total_chunks} chunks."})
 
-        # 2. 각 청크 처리 (순차적 또는 병렬 처리 구현 필요)
-        # 여기서는 간단하게 순차 처리 예시
-        for i, chunk in enumerate(chunks):
-            chunk_path_obj = chunk_output_dir / f"chunk_{i}.wav"
-            chunk_path = str(chunk_path_obj)
-            chunk_start_time_sec = (i * chunk_length_ms) / 1000.0 # 청크 시작 오프셋
+        # 각 청크 순차 처리
+        for i, chunk_audio_segment in enumerate(chunks):
+            chunk_file_name = f"chunk_{i}.wav"
+            chunk_path_obj = chunk_output_dir / chunk_file_name
+            chunk_path_str = str(chunk_path_obj)
+            # 현재 청크의 시작 시간 오프셋 (전체 오디오 기준, 초 단위)
+            current_chunk_start_offset_sec = (i * chunk_length_ms) / 1000.0
 
             try:
-                logger.debug(f"[Task {task_id}] Exporting chunk {i+1}/{total_chunks} to {chunk_path}")
-                chunk.export(chunk_path, format="wav")
+                logger.debug(f"[Task {task_id}] Exporting chunk {i+1}/{total_chunks} to {chunk_path_str}")
+                chunk_audio_segment.export(chunk_path_str, format="wav")
 
-                logger.info(f"[Task {task_id}] Starting STT for chunk {i+1}/{total_chunks}")
-                # STT 함수 호출
-                segments = transcribe_audio_file_with_timestamps(chunk_path, language)
-                logger.info(f"[Task {task_id}] STT complete for chunk {i+1}. Found {len(segments)} segments.")
+                logger.info(f"[Task {task_id}] Starting STT for chunk {i+1}/{total_chunks} (Path: {chunk_path_str})")
+                # STT 함수 호출 (결과는 [{ 'start': float, 'end': float, 'text': str }, ...])
+                segments_in_chunk = transcribe_audio_file_with_timestamps(chunk_path_str, language)
+                logger.info(f"[Task {task_id}] STT for chunk {i+1} completed. Found {len(segments_in_chunk)} segments.")
 
-                # 결과 세그먼트의 타임스탬프 조정 (청크 오프셋 반영)
-                adjusted_segments = []
-                for seg in segments:
-                    adjusted_seg = seg.copy()
-                    adjusted_seg['start'] += chunk_start_time_sec
-                    adjusted_seg['end'] += chunk_start_time_sec
-                    adjusted_segments.append(adjusted_seg)
-                    all_segments_combined.append(adjusted_seg) # 전체 결과 누적
+                # 현재 청크의 세그먼트들의 타임스탬프를 전체 오디오 기준으로 조정
+                adjusted_segments_for_this_chunk = []
+                for seg in segments_in_chunk:
+                    adjusted_seg = seg.copy() # 원본 수정을 피하기 위해 복사
+                    # round 함수로 소수점 자릿수 정리 (예: 3자리)
+                    adjusted_seg['start'] = round(seg['start'] + current_chunk_start_offset_sec, 3)
+                    adjusted_seg['end'] = round(seg['end'] + current_chunk_start_offset_sec, 3)
+                    adjusted_segments_for_this_chunk.append(adjusted_seg)
+                    all_segments_combined.append(adjusted_seg) # 전체 결과 리스트에도 누적
 
-                # 조정된 세그먼트를 Kafka로 전송
-                progress = 10 + int(90 * (i + 1) / total_chunks)
-                send_update_to_kafka(task_id, "PROCESSING", progress=progress, data=adjusted_segments)
+                # (선택적 유지) 현재 청크의 (타임스탬프 조정된) 일본어 결과만 Kafka로 전송
+                # 진행률 계산: 초기 10% + STT 진행률 (전체 85% 할당)
+                progress_after_chunk = 10 + int(85 * (i + 1) / total_chunks)
+                send_update_to_kafka(
+                    task_id,
+                    "PROCESSING",
+                    progress=progress_after_chunk,
+                    data=adjusted_segments_for_this_chunk # 현재 청크의 결과만
+                )
+                
+                # 사용한 임시 청크 파일 삭제 (성공적으로 처리된 경우)
+                try:
+                    os.remove(chunk_path_str)
+                    logger.debug(f"[Task {task_id}] Removed temporary chunk file: {chunk_path_str}")
+                except OSError as e_remove:
+                    logger.warning(f"[Task {task_id}] Could not remove temporary chunk file {chunk_path_str}: {e_remove}")
 
-                # 임시 청크 파일 삭제 (선택적)
-                # os.remove(chunk_path)
 
             except FileNotFoundError:
-                 logger.error(f"[Task {task_id}] Chunk file not found: {chunk_path}")
-                 send_update_to_kafka(task_id, "CHUNK_FAILED", error=f"Chunk file not found: {chunk_path}")
+                 logger.error(f"[Task {task_id}] Chunk file not found during STT processing: {chunk_path_str}")
+                 send_update_to_kafka(task_id, "CHUNK_FAILED", error=f"Chunk file not found: {chunk_path_str}")
                  has_chunk_error = True
-            except RuntimeError as stt_err: # STT 모델 로드 실패 등
+            except RuntimeError as stt_err: # STT 모델 자체의 런타임 오류 등
                  logger.error(f"[Task {task_id}] STT Runtime error for chunk {i+1}: {stt_err}", exc_info=True)
-                 send_update_to_kafka(task_id, "CHUNK_FAILED", error=f"STT Runtime error in chunk {i+1}: {stt_err}")
+                 send_update_to_kafka(task_id, "CHUNK_FAILED", error=f"STT error in chunk {i+1}: {stt_err}")
                  has_chunk_error = True
-            except Exception as e:
-                logger.error(f"[Task {task_id}] Error processing chunk {i+1}: {e}", exc_info=True)
-                send_update_to_kafka(task_id, "CHUNK_FAILED", error=f"Error processing chunk {i+1}: {e}")
+            except Exception as e: # 기타 예외 처리
+                logger.error(f"[Task {task_id}] Unexpected error processing chunk {i+1}: {e}", exc_info=True)
+                send_update_to_kafka(task_id, "CHUNK_FAILED", error=f"Error in chunk {i+1}: {e}")
                 has_chunk_error = True
-                # 오류 발생 시 계속 진행할지 결정
+                # 중대한 오류 시 여기서 루프를 중단할지(break) 아니면 계속 진행할지 결정 필요
 
-        # 3. 최종 완료/실패 메시지 전송
+        # --- 모든 청크 처리 완료 후 ---
         if has_chunk_error:
-            logger.warning(f"[Task {task_id}] Processing finished with errors.")
-            send_update_to_kafka(task_id, "FAILED", progress=100, error="Processing completed with errors in some chunks.")
+            logger.warning(f"[Task {task_id}] STT processing finished with errors in some chunks.")
+            send_update_to_kafka(task_id, "FAILED", progress=100, error="Processing completed with errors during STT.")
         else:
-            logger.info(f"[Task {task_id}] Processing completed successfully.")
-            # 최종 완료 메시지 (선택적으로 전체 세그먼트 포함 가능)
-            # send_update_to_kafka(task_id, "COMPLETED", progress=100, data=all_segments_combined)
-            send_update_to_kafka(task_id, "COMPLETED", progress=100)
+            logger.info(f"[Task {task_id}] All STT chunks processed successfully. Sending combined segments for batch translation trigger.")
+            # *** 핵심 수정: 모든 일본어 세그먼트를 포함한 메시지를 API에 전달하여 일괄 번역 트리거 ***
+            send_update_to_kafka(
+                task_id,
+                "STT_COMPLETED_ALL_SEGMENTS", # API가 이 상태를 보고 일괄 번역 시작
+                progress=95, # STT 완료, 번역 대기 상태 (95%로 설정)
+                data=all_segments_combined # 모든 (타임스탬프 조정된) 일본어 세그먼트 리스트
+            )
 
-
-    except FileNotFoundError:
+    except FileNotFoundError: # 메인 오디오 파일 로드 실패
         logger.error(f"[Task {task_id}] Main audio file not found: {wav_file_path}")
-        send_update_to_kafka(task_id, "FAILED", error="Input audio file not found.")
-    except Exception as e:
-        logger.error(f"[Task {task_id}] Unexpected error during main processing: {e}", exc_info=True)
+        send_update_to_kafka(task_id, "FAILED", error=f"Input audio file not found: {wav_file_path}")
+    except Exception as e: # 그 외 예기치 못한 오류
+        logger.error(f"[Task {task_id}] Unexpected error during main STT processing: {e}", exc_info=True)
         send_update_to_kafka(task_id, "FAILED", error=f"An unexpected error occurred: {e}")
     finally:
-        # 최종적으로 임시 청크 디렉토리 정리 (선택적)
+        # 임시 청크 디렉토리 정리
         try:
             if chunk_output_dir.exists():
-                for p in chunk_output_dir.glob("*.wav"):
-                    os.remove(p)
-                chunk_output_dir.rmdir()
-                logger.info(f"[Task {task_id}] Cleaned up chunk directory: {chunk_output_dir}")
-        except Exception as e:
-            logger.warning(f"[Task {task_id}] Could not clean up chunk directory {chunk_output_dir}: {e}")
+                # 디렉토리 내 파일들을 먼저 삭제 (선택적: shutil.rmtree 사용 시 불필요)
+                # for p_file in chunk_output_dir.glob("*.wav"):
+                #     try:
+                #         os.remove(p_file)
+                #     except Exception as e_remove_final:
+                #         logger.warning(f"[Task {task_id}] Failed to remove chunk file {p_file} during final cleanup: {e_remove_final}")
+                # 디렉토리 삭제 (shutil.rmtree 사용 권장)
+                import shutil
+                shutil.rmtree(chunk_output_dir)
+                logger.info(f"[Task {task_id}] Successfully cleaned up chunk directory: {chunk_output_dir}")
+        except Exception as e_cleanup:
+            logger.warning(f"[Task {task_id}] Error during final cleanup of chunk directory {chunk_output_dir}: {e_cleanup}")
+
 
 # --- Kafka Consumer 루프 ---
 def run_consumer():

--- a/backend/services/stt-processor/src/main.py
+++ b/backend/services/stt-processor/src/main.py
@@ -40,54 +40,55 @@ else:
     logger.warning("GEMINI_API_KEY environment variable not found. Translation via Gemini will be disabled.")
     gemini_translation_model = None
 
-async def translate_japanese_to_korean_with_gemini(japanese_text: str) -> Union[str, None]:
-    """주어진 일본어 텍스트를 Gemini API를 사용하여 한국어로 번역합니다."""
-    if not gemini_translation_model: # 초기화된 모델 인스턴스 사용
-        logger.warning("Gemini translation model is not initialized. Skipping translation.")
-        return None
+# async def translate_japanese_to_korean_with_gemini(japanese_text: str) -> Union[str, None]:
+#     """주어진 일본어 텍스트를 Gemini API를 사용하여 한국어로 번역합니다."""
 
-    # --- 프롬프트 엔지니어링 (구어체 및 자연스러운 번역 유도) ---
-    # 예시 프롬프트입니다. 실제 사용 시 다양한 테스트를 통해 최적화하세요.
-    prompt = f"""다음 일본어 구어체 문장을 매우 자연스러운 한국어 구어체로 번역해주세요.
-                일본어: "{japanese_text}"
-                한국어:"""
+#     if not gemini_translation_model: # 초기화된 모델 인스턴스 사용
+#         logger.warning("Gemini translation model is not initialized. Skipping translation.")
+#         return None
+
+#     # --- 프롬프트 엔지니어링 (구어체 및 자연스러운 번역 유도) ---
+#     # 예시 프롬프트입니다. 실제 사용 시 다양한 테스트를 통해 최적화하세요.
+#     prompt = f"""다음 일본어 구어체 문장을 매우 자연스러운 한국어 구어체로 번역해주세요.
+#                 일본어: "{japanese_text}"
+#                 한국어:"""
     
-    logger.debug(f"Sending text to Gemini for translation: '{japanese_text}'")
+#     logger.debug(f"Sending text to Gemini for translation: '{japanese_text}'")
 
-    try:
-        # API 호출 시 안전 설정 및 생성 설정 (선택적)
-        generation_config = genai.types.GenerationConfig(
-            temperature=0.7, # 창의성 조절 (0.0 ~ 1.0)
-            # max_output_tokens=..., # 필요시 최대 출력 토큰 수 제한
-        )
-        # 안전 설정 (유해 콘텐츠 차단 레벨 조정 - 필요시)
-        # safety_settings = [
-        #     {"category": "HARM_CATEGORY_HARASSMENT", "threshold": "BLOCK_NONE"},
-        #     {"category": "HARM_CATEGORY_HATE_SPEECH", "threshold": "BLOCK_NONE"},
-        #     {"category": "HARM_CATEGORY_SEXUALLY_EXPLICIT", "threshold": "BLOCK_NONE"},
-        #     {"category": "HARM_CATEGORY_DANGEROUS_CONTENT", "threshold": "BLOCK_NONE"},
-        # ]
+#     try:
+#         # API 호출 시 안전 설정 및 생성 설정 (선택적)
+#         generation_config = genai.types.GenerationConfig(
+#             temperature=0.7, # 창의성 조절 (0.0 ~ 1.0)
+#             # max_output_tokens=..., # 필요시 최대 출력 토큰 수 제한
+#         )
+#         # 안전 설정 (유해 콘텐츠 차단 레벨 조정 - 필요시)
+#         # safety_settings = [
+#         #     {"category": "HARM_CATEGORY_HARASSMENT", "threshold": "BLOCK_NONE"},
+#         #     {"category": "HARM_CATEGORY_HATE_SPEECH", "threshold": "BLOCK_NONE"},
+#         #     {"category": "HARM_CATEGORY_SEXUALLY_EXPLICIT", "threshold": "BLOCK_NONE"},
+#         #     {"category": "HARM_CATEGORY_DANGEROUS_CONTENT", "threshold": "BLOCK_NONE"},
+#         # ]
 
-        # 비동기 API 호출
-        response = await gemini_translation_model.generate_content_async(
-            prompt,
-            generation_config=generation_config,
-            # safety_settings=safety_settings # 안전 설정 적용 시
-        )
+#         # 비동기 API 호출
+#         response = await gemini_translation_model.generate_content_async(
+#             prompt,
+#             generation_config=generation_config,
+#             # safety_settings=safety_settings # 안전 설정 적용 시
+#         )
 
-        if response.parts:
-            translated_korean_text = response.text.strip()
-            logger.debug(f"Gemini translation successful: '{japanese_text}' -> '{translated_korean_text}'")
-            return translated_korean_text
-        else:
-            # 응답에 텍스트 파트가 없는 경우 (차단 등)
-            block_reason = response.prompt_feedback.block_reason if response.prompt_feedback else "Unknown"
-            safety_ratings_str = str(response.candidates[0].safety_ratings) if response.candidates and response.candidates[0].safety_ratings else "N/A"
-            logger.warning(f"Gemini response for '{japanese_text}' did not contain text parts. Blocked: {block_reason}, SafetyRatings: {safety_ratings_str}")
-            return "[번역 실패: Gemini 응답 없음]"
-    except Exception as e:
-        logger.error(f"Error during Gemini API call for text '{japanese_text}': {e}", exc_info=True)
-        return "[번역 오류 발생]"
+#         if response.parts:
+#             translated_korean_text = response.text.strip()
+#             logger.debug(f"Gemini translation successful: '{japanese_text}' -> '{translated_korean_text}'")
+#             return translated_korean_text
+#         else:
+#             # 응답에 텍스트 파트가 없는 경우 (차단 등)
+#             block_reason = response.prompt_feedback.block_reason if response.prompt_feedback else "Unknown"
+#             safety_ratings_str = str(response.candidates[0].safety_ratings) if response.candidates and response.candidates[0].safety_ratings else "N/A"
+#             logger.warning(f"Gemini response for '{japanese_text}' did not contain text parts. Blocked: {block_reason}, SafetyRatings: {safety_ratings_str}")
+#             return "[번역 실패: Gemini 응답 없음]"
+#     except Exception as e:
+#         logger.error(f"Error during Gemini API call for text '{japanese_text}': {e}", exc_info=True)
+#         return "[번역 오류 발생]"
 
 # --- Kafka Producer 초기화 ---
 # Producer는 비교적 가벼우므로 요청 시 생성하거나, 앱 시작 시 생성 가능
@@ -124,6 +125,79 @@ for attempt in range(MAX_RETRIES):
          # 예상치 못한 오류는 바로 루프 중단 고려 가능
          break
 
+SEGMENT_SEPARATOR = "[TRANSLATION_SEGMENT_BREAK]" # 문장 구분자 정의
+
+async def translate_batched_japanese_to_korean_with_gemini(
+    japanese_segments_texts: List[str]
+) -> List[Union[str, None]]:
+    """
+    일본어 텍스트 리스트를 받아 하나의 요청으로 Gemini API에 번역을 요청하고,
+    번역된 한국어 텍스트 리스트를 반환합니다.
+    """
+    if not gemini_translation_model:
+        logger.warning("Gemini translation model not initialized. Skipping batch translation.")
+        return ["[번역 건너뜀 - 모델 미초기화]" for _ in japanese_segments_texts]
+
+    if not japanese_segments_texts:
+        return []
+    
+    example_jp_input = f"こんにちは{SEGMENT_SEPARATOR}\nお元気ですか" # 입력 시 구분자는 \n 없이 사용 가능
+    example_ko_output = f"안녕하세요.{SEGMENT_SEPARATOR}\n잘 지내세요?" # 출력 시 번호, 구분자, 줄바꿈 명시
+
+
+    # 구분자를 사용하여 모든 일본어 텍스트를 하나의 문자열로 합침
+    combined_japanese_text = f"\n{SEGMENT_SEPARATOR}\n".join(japanese_segments_texts)
+
+    prompt = f"""다음은 유튜브에서 추출해낸 총 {len(japanese_segments_texts)}개의 독립적인 일본어 구어체 문장들입니다. 각 문장은 "{SEGMENT_SEPARATOR}"로 구분되어 있습니다.
+    맥락에 맞게 매우 자연스러운 한국어 구어체로 번역하고, 각 번역된 문장 뒤에는 반드시 원래의 "{SEGMENT_SEPARATOR}" 구분자를 정확히 유지해주세요.
+    최종적으로 번역된 한국어 문장도 정확히 {len(japanese_segments_texts)}개가 되어야 합니다.
+    각 번역된 문장 외에는 어떠한 부연 설명, 인사말 등을 절대 포함하지 마세요.
+
+    예시:
+    일본어 원문:
+    {example_jp_input}
+
+    한국어 번역:
+    {example_ko_output}
+
+    일본어 원문:
+    {combined_japanese_text}
+
+    한국어 번역:"""
+
+    logger.info(f"Sending {len(japanese_segments_texts)} segments to Gemini for batch translation.")
+    logger.debug(f"Combined Japanese text for Gemini:\n{combined_japanese_text}")
+
+    try:
+        generation_config = genai.types.GenerationConfig(temperature=0.7)
+        response = await gemini_translation_model.generate_content_async(
+            prompt,
+            generation_config=generation_config,
+        )
+
+        if response.parts:
+            combined_korean_text = response.text.strip()
+            logger.debug(f"Combined Korean translation from Gemini:\n{combined_korean_text}")
+
+            # 구분자를 기준으로 번역된 한국어 텍스트 분리
+            translated_korean_segments = combined_korean_text.split(f"{SEGMENT_SEPARATOR}\n")
+            
+            # 원본 세그먼트 수와 번역된 세그먼트 수가 일치하는지 확인
+            if len(translated_korean_segments) == len(japanese_segments_texts):
+                logger.info(f"Batch translation successful. Received {len(translated_korean_segments)} translated segments.")
+                return translated_korean_segments
+            else:
+                logger.error(f"Mismatch in segment count after batch translation. Expected {len(japanese_segments_texts)}, got {len(translated_korean_segments)}. Full response: '{combined_korean_text}'")
+                # 오류 처리: 개별 번역으로 전환하거나, 에러 메시지 반환
+                return ["[일괄 번역 분할 오류]" for _ in japanese_segments_texts]
+        else:
+            block_reason = response.prompt_feedback.block_reason if response.prompt_feedback else "Unknown"
+            logger.warning(f"Gemini batch response did not contain text parts. Blocked: {block_reason}")
+            return ["[일괄 번역 실패: Gemini 응답 없음]" for _ in japanese_segments_texts]
+    except Exception as e:
+        logger.error(f"Error during Gemini batch API call: {e}", exc_info=True)
+        return ["[일괄 번역 중 오류 발생]" for _ in japanese_segments_texts]
+
 # --- FastAPI 앱 생성 및 CORS 설정 ---
 app = FastAPI(title="Kafka-based STT Processor API", version="0.3.0")
 # ... (CORS 미들웨어 설정은 이전과 동일하게 추가) ...
@@ -152,7 +226,8 @@ consumer = None # Consumer 객체를 전역 또는 클래스 멤버로 관리
 def _run_kafka_consumer_loop(consumer: KafkaConsumer, main_loop: asyncio.AbstractEventLoop):
     """
     백그라운드 스레드에서 실행될 Kafka Consumer 루프.
-    STT 결과를 받아 Gemini로 번역 후 WebSocket 통신 및 Redis 저장을 수행합니다.
+    STT 결과를 받아, 최종 STT 완료 시점에만 Gemini로 일괄 번역 후 
+    WebSocket 통신 및 Redis 저장을 수행합니다.
     """
     redis_client = get_redis_client()
     logger.info("Kafka Consumer thread started. Waiting for messages from topic '{}'...".format(STT_RESULT_TOPIC))
@@ -166,135 +241,163 @@ def _run_kafka_consumer_loop(consumer: KafkaConsumer, main_loop: asyncio.Abstrac
             logger.info(f"!!!!!!!!!! [Thread] Message Received from Kafka: {message.topic}/{message.partition}/{message.offset}: key={message.key} !!!!!!!!!!")
 
             try:
-                result_data = message.value # JSON 역직렬화된 dict (KafkaConsumer 설정에 따름)
+                result_data = message.value # KafkaConsumer 설정에 따라 이미 dict로 변환되었을 것
                 task_id = result_data.get('task_id')
 
                 if not task_id:
                     logger.warning(f"[Thread] Received message without task_id: {result_data}")
-                    continue # task_id 없으면 다음 메시지로
+                    continue 
 
-                logger.info(f"[Thread][Task {task_id}] Received Kafka message, Status: {result_data.get('status')}, Progress: {result_data.get('progress')}")
-                logger.debug(f"[Thread][Task {task_id}] Raw message data: {result_data.get('data')}")
+                current_status = result_data.get("status", "UNKNOWN")
+                logger.info(f"[Thread][Task {task_id}] Kafka message received. Status: {current_status}, Progress: {result_data.get('progress')}")
+                logger.debug(f"[Thread][Task {task_id}] Raw message data payload: {result_data.get('data')}")
 
-                # --- STT 세그먼트 데이터가 있고, 번역이 필요한 경우 ---
-                # result_data["data"]가 리스트이고, 그 안에 "text" 키를 가진 딕셔너리들이 있다면 STT 결과로 간주
-                is_stt_segment_data = (
-                    result_data.get("data")
-                    and isinstance(result_data["data"], list)
-                    and len(result_data["data"]) > 0
-                    and isinstance(result_data["data"][0], dict)
-                    and "text" in result_data["data"][0] # 첫 번째 요소에 text 필드 확인
-                )
-
-                if is_stt_segment_data:
-                    stt_segments = result_data["data"]
-                    logger.info(f"[Thread][Task {task_id}] Found {len(stt_segments)} STT segments. Proceeding to translate with Gemini.")
-
-                    # --- 비동기 번역 작업을 위한 헬퍼 함수 ---
-                    async def _translate_batch_async(segments_to_translate):
-                        translation_coroutines = []
-                        for seg_idx, segment_content in enumerate(segments_to_translate):
-                            jp_text = segment_content.get("text")
-                            if jp_text and isinstance(jp_text, str): # 실제 텍스트가 있는지 확인
-                                logger.debug(f"[Thread][Task {task_id}][Seg {seg_idx+1}] Scheduling translation for: '{jp_text}'")
-                                translation_coroutines.append(translate_japanese_to_korean_with_gemini(jp_text))
-                            else:
-                                # 번역할 일본어 텍스트가 없는 경우 (예: 빈 문자열, None)
-                                logger.debug(f"[Thread][Task {task_id}][Seg {seg_idx+1}] No Japanese text to translate, skipping Gemini call.")
-                                translation_coroutines.append(asyncio.sleep(0, result="[원본 텍스트 없음 또는 부적절]")) # 즉시 완료, 플레이스홀더 반환
-                        
-                        # 모든 번역 작업을 동시에 실행하고 결과 수집 (개별 작업 오류도 반환)
-                        return await asyncio.gather(*translation_coroutines, return_exceptions=True)
-                    # --- 비동기 번역 헬퍼 함수 끝 ---
-
-                    # 메인 이벤트 루프에서 번역 작업들 실행 및 결과 대기
-                    if main_loop and main_loop.is_running() and gemini_translation_model: # Gemini 모델 초기화 확인
-                        future = asyncio.run_coroutine_threadsafe(_translate_batch_async(stt_segments), main_loop)
-                        try:
-                            # 번역 작업 타임아웃 설정 (넉넉하게, 세그먼트 수에 따라 조절)
-                            # 예: 기본 30초 + (세그먼트당 평균 5초 * 세그먼트 수)
-                            timeout_seconds = 30 + (len(stt_segments) * 5) 
-                            logger.debug(f"[Thread][Task {task_id}] Waiting for {len(stt_segments)} translations with timeout {timeout_seconds}s...")
-                            translated_texts_or_errors_list = future.result(timeout=timeout_seconds)
-                            logger.info(f"[Thread][Task {task_id}] Gemini translation batch completed.")
-
-                            # 번역 결과를 원본 세그먼트에 'korean_text' 키로 추가
-                            for i, segment in enumerate(stt_segments):
-                                original_jp_text = segment.get("text", "[원본 JP 없음]") # 로깅용
-                                if i < len(translated_texts_or_errors_list):
-                                    translation_result = translated_texts_or_errors_list[i]
-                                    if isinstance(translation_result, Exception):
-                                        # 개별 번역 작업에서 예외 발생 시
-                                        logger.error(f"[Thread][Task {task_id}][Seg {i+1}] Translation failed for '{original_jp_text}': {translation_result}")
-                                        segment["korean_text"] = "[번역 중 오류 발생]"
-                                    elif translation_result is None:
-                                        # translate_japanese_to_korean_with_gemini 가 None 반환 시 (API 키 없음 등)
-                                        logger.warning(f"[Thread][Task {task_id}][Seg {i+1}] Translation for '{original_jp_text}' returned None.")
-                                        segment["korean_text"] = "[번역 결과 없음]"
-                                    else:
-                                        segment["korean_text"] = str(translation_result) # 문자열로 확실히 변환
-                                        # --- 번역된 한국어 내용 로그로 바로 확인 ---
-                                        logger.info(f"[Thread][Task {task_id}][Seg {i+1}] JP: '{original_jp_text}'  ==>  KO: '{segment['korean_text']}'")
-                                else:
-                                    logger.warning(f"[Thread][Task {task_id}][Seg {i+1}] Translation result missing for '{original_jp_text}'.")
-                                    segment["korean_text"] = "[번역 누락]"
-                        except asyncio.TimeoutError:
-                            logger.error(f"[Thread][Task {task_id}] Gemini translation for segments timed out after {timeout_seconds}s.")
-                            for segment in stt_segments: segment["korean_text"] = "[번역 시간 초과]"
-                        except Exception as e_trans_batch:
-                            logger.error(f"[Thread][Task {task_id}] An error occurred during batch Gemini translation execution: {e_trans_batch}", exc_info=True)
-                            for segment in stt_segments: segment["korean_text"] = "[번역 시스템 오류]"
-                    elif not gemini_translation_model:
-                        logger.warning(f"[Thread][Task {task_id}] Gemini model not initialized. Skipping all translations.")
-                        for segment in stt_segments: segment["korean_text"] = "[번역 건너뜀 - 모델 미초기화]"
-                    else: # main_loop 없거나 실행 중 아닐 때
-                        logger.warning(f"[Thread][Task {task_id}] Main event loop not available. Skipping all translations.")
-                        for segment in stt_segments: segment["korean_text"] = "[번역 건너뜀 - 루프 없음]"
+                # --- 핵심 로직: 상태에 따라 분기 처리 ---
+                if current_status == "STT_COMPLETED_ALL_SEGMENTS":
+                    # 워커가 모든 STT 처리를 완료하고 전체 일본어 세그먼트를 보낸 경우
+                    stt_segments = result_data.get("data")
                     
-                    result_data["data"] = stt_segments # 번역된 텍스트가 포함된 세그먼트로 업데이트
-                # --- STT 세그먼트 번역 처리 끝 ---
+                    # 데이터 유효성 검사 (리스트 형태인지, 비어있지 않은지 등)
+                    if isinstance(stt_segments, list):
+                        if not stt_segments: # STT 결과 세그먼트가 없는 경우 (예: 무음 영상)
+                            logger.info(f"[Thread][Task {task_id}] STT produced no segments. Finalizing as COMPLETED with empty data.")
+                            result_data["status"] = "COMPLETED"
+                            result_data["progress"] = 100
+                            result_data["data"] = [] # 데이터는 빈 리스트로 확실히 설정
+                        else: # STT 세그먼트가 있는 경우, 일괄 번역 진행
+                            logger.info(f"[Thread][Task {task_id}] Received all {len(stt_segments)} STT segments. Starting batch translation with Gemini.")
+                            
+                            # 번역할 일본어 텍스트만 추출
+                            japanese_texts_to_translate = [
+                                seg.get("text", "") for seg in stt_segments if isinstance(seg, dict) and seg.get("text")
+                            ]
+                            
+                            if not japanese_texts_to_translate: # 추출된 일본어 텍스트가 없는 경우
+                                logger.warning(f"[Thread][Task {task_id}] No valid Japanese text found in segments to translate.")
+                                for segment in stt_segments: # 모든 세그먼트에 플레이스홀더 추가
+                                     if isinstance(segment, dict): segment["korean_text"] = "[원본 JP 텍스트 없음]"
+                                result_data["status"] = "COMPLETED" # 번역할 내용 없으므로 바로 완료
+                                result_data["progress"] = 100
 
-                # WebSocket으로 업데이트된 result_data 전송 및 Redis 저장
+                            elif main_loop and main_loop.is_running() and gemini_translation_model:
+                                # 비동기 일괄 번역 함수 호출
+                                async def _perform_batch_translation_async():
+                                    return await translate_batched_japanese_to_korean_with_gemini(japanese_texts_to_translate)
+
+                                future = asyncio.run_coroutine_threadsafe(_perform_batch_translation_async(), main_loop)
+                                try:
+                                    timeout_seconds = 60 + (len(japanese_texts_to_translate) * 5) # 타임아웃 조절
+                                    logger.debug(f"[Thread][Task {task_id}] Waiting for batch translation from Gemini (timeout: {timeout_seconds}s)...")
+                                    translated_korean_list = future.result(timeout=timeout_seconds)
+                                    logger.info(f"[Thread][Task {task_id}] Gemini batch translation finished.")
+
+                                    # 번역 결과를 원본 세그먼트에 매칭하여 추가
+                                    translation_idx = 0
+                                    for segment in stt_segments:
+                                        if isinstance(segment, dict) and segment.get("text"): # 실제 텍스트가 있었던 세그먼트에만 매칭
+                                            if translation_idx < len(translated_korean_list):
+                                                ko_text_result = translated_korean_list[translation_idx]
+                                                if isinstance(ko_text_result, Exception):
+                                                    segment["korean_text"] = "[번역 중 오류]"
+                                                    logger.error(f"[Thread][Task {task_id}] Translation failed for JP: '{segment.get('text')}': {ko_text_result}")
+                                                else:
+                                                    segment["korean_text"] = str(ko_text_result) if ko_text_result else "[번역 결과 없음]"
+                                                logger.info(f"[Thread][Task {task_id}] JP: '{segment.get('text')}'  ==>  KO: '{segment['korean_text']}'")
+                                                translation_idx += 1
+                                            else: # 번역 결과 리스트가 예상보다 짧은 경우
+                                                segment["korean_text"] = "[번역 누락]"
+                                                logger.warning(f"[Thread][Task {task_id}] Missing translation for JP: '{segment.get('text')}'")
+                                        elif isinstance(segment, dict): # text 필드가 없는 segment
+                                            segment["korean_text"] = "[원본 JP 텍스트 없음]"
+
+                                    result_data["status"] = "COMPLETED" # 모든 작업 완료
+                                    result_data["progress"] = 100
+                                except asyncio.TimeoutError:
+                                    logger.error(f"[Thread][Task {task_id}] Gemini batch translation timed out.")
+                                    for segment in stt_segments: 
+                                        if isinstance(segment, dict): segment["korean_text"] = "[일괄 번역 시간 초과]"
+                                    result_data["status"] = "FAILED"; result_data["error"] = "Translation timed out"
+                                except Exception as e_trans_batch:
+                                    logger.error(f"[Thread][Task {task_id}] Error in batch translation: {e_trans_batch}", exc_info=True)
+                                    for segment in stt_segments: 
+                                        if isinstance(segment, dict): segment["korean_text"] = "[일괄 번역 시스템 오류]"
+                                    result_data["status"] = "FAILED"; result_data["error"] = "Translation system error"
+                            elif not gemini_translation_model:
+                                logger.warning(f"[Thread][Task {task_id}] Gemini model not initialized. Skipping translation for STT_COMPLETED_ALL_SEGMENTS.")
+                                for segment in stt_segments: 
+                                    if isinstance(segment, dict): segment["korean_text"] = "[번역 건너뜀 - 모델 미초기화]"
+                                result_data["status"] = "COMPLETED" # STT는 완료됨
+                                result_data["progress"] = 100 # 번역은 안됐지만 진행률은 100
+                            else: # main_loop 문제
+                                logger.warning(f"[Thread][Task {task_id}] Main event loop not available. Skipping translation for STT_COMPLETED_ALL_SEGMENTS.")
+                                for segment in stt_segments: 
+                                    if isinstance(segment, dict): segment["korean_text"] = "[번역 건너뜀 - 루프 없음]"
+                                result_data["status"] = "COMPLETED"
+                                result_data["progress"] = 100
+                    else: # stt_segments가 리스트가 아닌 경우
+                        logger.error(f"[Thread][Task {task_id}] 'STT_COMPLETED_ALL_SEGMENTS' status but 'data' is not a list: {stt_segments}")
+                        result_data["status"] = "FAILED"
+                        result_data["error"] = "Invalid STT segment data format for translation."
+                    
+                    # result_data["data"]는 이미 stt_segments로 업데이트 되어 있음
+
+                elif current_status == "PROCESSING":
+                    # 중간 STT 결과 (일본어 텍스트만) 또는 상태 메시지
+                    # 이 메시지들은 번역 없이 그대로 전달
+                    logger.info(f"[Thread][Task {task_id}] Forwarding 'PROCESSING' message as is (no translation).")
+                    # result_data는 이미 수신한 그대로 사용
+                
+                elif current_status == "FAILED" or "CHUNK_FAILED" in current_status:
+                    # 워커에서 발생한 실패 상태 그대로 전달
+                    logger.warning(f"[Thread][Task {task_id}] Forwarding 'FAILED' or 'CHUNK_FAILED' message as is.")
+                    # result_data는 이미 수신한 그대로 사용
+
+                else:
+                    logger.warning(f"[Thread][Task {task_id}] Received message with unhandled status '{current_status}'. Forwarding as is.")
+                    # 알 수 없는 다른 상태도 일단 그대로 전달
+
+                # --- 최종 메시지 전송 및 저장 (모든 상태 공통) ---
+                # result_data는 위 분기에서 상태, 진행률, 데이터(번역 포함 또는 미포함)가 업데이트 되었음
                 if main_loop and main_loop.is_running():
-                    logger.debug(f"[Thread][Task {task_id}] Scheduling WebSocket send and Redis save.")
+                    logger.debug(f"[Thread][Task {task_id}] Scheduling WebSocket send with final status: {result_data.get('status')}, progress: {result_data.get('progress')}")
                     asyncio.run_coroutine_threadsafe(
                         _send_ws_update_async(
                             task_id,
-                            result_data.get("status", "UNKNOWN"),
-                            result_data.get("progress"),
-                            result_data.get("data"), # 이제 여기에 korean_text 포함됨
+                            result_data.get("status"), # 최종 결정된 status
+                            result_data.get("progress"), # 최종 결정된 progress
+                            result_data.get("data"),     # 최종 데이터 (번역 포함 또는 JP만)
                             result_data.get("error")
                         ),
                         main_loop
                     )
                 else:
-                    logger.warning(f"[Thread][Task {task_id}] Main event loop not available for WebSocket/Redis update.")
-                
-                # Redis 저장 (동기적, 에러 핸들링 추가)
+                    logger.warning(f"[Thread][Task {task_id}] Main event loop not available for final WebSocket/Redis update.")
+
                 if redis_client:
                     try:
                         redis_key = f"ws_messages:{task_id}"
-                        # result_data가 dict인지 확인 (value_deserializer에 의해 이미 dict여야 함)
-                        message_to_store = result_data if isinstance(result_data, dict) else {"error": "Invalid data format for Redis"}
-                        message_json = json.dumps(message_to_store) # 이제 korean_text 포함
+                        message_to_store = result_data if isinstance(result_data, dict) else {"error": "Invalid data format for Redis storage"}
+                        message_json = json.dumps(message_to_store)
                         redis_client.rpush(redis_key, message_json)
                         redis_client.expire(redis_key, get_message_ttl())
-                        logger.debug(f"[Thread][Task {task_id}] Saved updated message to Redis list {redis_key}")
+                        logger.debug(f"[Thread][Task {task_id}] Saved final message to Redis: {message_json[:200]}...") # 로그 너무 길지 않게
                     except Exception as e_redis:
-                        logger.error(f"[Thread][Task {task_id}] Failed to save message to Redis: {e_redis}", exc_info=True)
+                        logger.error(f"[Thread][Task {task_id}] Failed to save final message to Redis: {e_redis}", exc_info=True)
 
             except json.JSONDecodeError as e_json_decode:
                  logger.error(f"[Thread] Failed to decode Kafka message value: {message.value}. Error: {e_json_decode}", exc_info=True)
-            except Exception as e_msg_proc:
-                logger.error(f"[Thread][Task {task_id if 'task_id' in locals() else 'Unknown'}] Error processing Kafka message: {e_msg_proc}", exc_info=True)
+            except Exception as e_msg_proc: # 개별 메시지 처리 중 예외
+                task_id_for_error = task_id if 'task_id' in locals() and task_id else 'UnknownTaskID'
+                logger.error(f"[Thread][Task {task_id_for_error}] Error processing individual Kafka message: {e_msg_proc}", exc_info=True)
+                # 이 경우 해당 메시지 처리는 실패하고 다음 메시지로 넘어감
 
-    except KeyboardInterrupt: # Ctrl+C 등으로 스레드 종료 시
+    except KeyboardInterrupt:
         logger.info("Kafka Consumer thread received KeyboardInterrupt. Exiting...")
-    except Exception as e_consumer_loop:
-        logger.error(f"Fatal error in Kafka Consumer loop: {e_consumer_loop}", exc_info=True)
+    except Exception as e_consumer_loop: # 루프 자체의 심각한 오류
+        logger.error(f"Fatal error in Kafka Consumer main loop: {e_consumer_loop}", exc_info=True)
     finally:
         logger.info("Closing Kafka Consumer in thread.")
-        if consumer: # consumer 객체가 None이 아닐 때만 close 호출
+        if consumer:
             consumer.close()
 
 # --- 앱 시작 시 Kafka Consumer 스레드 실행 ---

--- a/backend/services/stt-processor/src/main.py
+++ b/backend/services/stt-processor/src/main.py
@@ -1,10 +1,11 @@
 import logging
 import uuid # 고유 Task ID 생성용
 import asyncio
+import google.generativeai as genai
 import os
 from fastapi import FastAPI, HTTPException, Body, WebSocket, WebSocketDisconnect, Depends, BackgroundTasks
 from pydantic import BaseModel, Field
-from typing import Dict, List, Any
+from typing import Union, Dict, List, Any
 from fastapi.middleware.cors import CORSMiddleware # 이 import 확인
 import json
 import time
@@ -21,6 +22,72 @@ from .redis_client import get_redis_client, get_message_ttl # Redis는 히스토
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
+
+# 환경 변수에서 Gemini API 키 로드
+GEMINI_API_KEY = os.getenv("GEMINI_API_KEY")
+if GEMINI_API_KEY:
+    try:
+        genai.configure(api_key=GEMINI_API_KEY)
+        logger.info("Gemini API Key configured successfully.")
+        # 번역에 사용할 모델 인스턴스 (애플리케이션 로드 시 한 번만 생성 권장)
+        # 사용 가능한 모델: gemini-1.5-flash-latest, gemini-1.5-pro-latest, gemini-pro 등
+        gemini_translation_model = genai.GenerativeModel('gemini-1.5-flash-latest')
+        logger.info("Gemini model 'gemini-1.5-flash-latest' initialized for translation.")
+    except Exception as e:
+        logger.error(f"Failed to configure Gemini API or initialize model: {e}", exc_info=True)
+        gemini_translation_model = None # 초기화 실패 시 None으로 설정
+else:
+    logger.warning("GEMINI_API_KEY environment variable not found. Translation via Gemini will be disabled.")
+    gemini_translation_model = None
+
+async def translate_japanese_to_korean_with_gemini(japanese_text: str) -> Union[str, None]:
+    """주어진 일본어 텍스트를 Gemini API를 사용하여 한국어로 번역합니다."""
+    if not gemini_translation_model: # 초기화된 모델 인스턴스 사용
+        logger.warning("Gemini translation model is not initialized. Skipping translation.")
+        return None
+
+    # --- 프롬프트 엔지니어링 (구어체 및 자연스러운 번역 유도) ---
+    # 예시 프롬프트입니다. 실제 사용 시 다양한 테스트를 통해 최적화하세요.
+    prompt = f"""다음 일본어 구어체 문장을 매우 자연스러운 한국어 구어체로 번역해주세요.
+                일본어: "{japanese_text}"
+                한국어:"""
+    
+    logger.debug(f"Sending text to Gemini for translation: '{japanese_text}'")
+
+    try:
+        # API 호출 시 안전 설정 및 생성 설정 (선택적)
+        generation_config = genai.types.GenerationConfig(
+            temperature=0.7, # 창의성 조절 (0.0 ~ 1.0)
+            # max_output_tokens=..., # 필요시 최대 출력 토큰 수 제한
+        )
+        # 안전 설정 (유해 콘텐츠 차단 레벨 조정 - 필요시)
+        # safety_settings = [
+        #     {"category": "HARM_CATEGORY_HARASSMENT", "threshold": "BLOCK_NONE"},
+        #     {"category": "HARM_CATEGORY_HATE_SPEECH", "threshold": "BLOCK_NONE"},
+        #     {"category": "HARM_CATEGORY_SEXUALLY_EXPLICIT", "threshold": "BLOCK_NONE"},
+        #     {"category": "HARM_CATEGORY_DANGEROUS_CONTENT", "threshold": "BLOCK_NONE"},
+        # ]
+
+        # 비동기 API 호출
+        response = await gemini_translation_model.generate_content_async(
+            prompt,
+            generation_config=generation_config,
+            # safety_settings=safety_settings # 안전 설정 적용 시
+        )
+
+        if response.parts:
+            translated_korean_text = response.text.strip()
+            logger.debug(f"Gemini translation successful: '{japanese_text}' -> '{translated_korean_text}'")
+            return translated_korean_text
+        else:
+            # 응답에 텍스트 파트가 없는 경우 (차단 등)
+            block_reason = response.prompt_feedback.block_reason if response.prompt_feedback else "Unknown"
+            safety_ratings_str = str(response.candidates[0].safety_ratings) if response.candidates and response.candidates[0].safety_ratings else "N/A"
+            logger.warning(f"Gemini response for '{japanese_text}' did not contain text parts. Blocked: {block_reason}, SafetyRatings: {safety_ratings_str}")
+            return "[번역 실패: Gemini 응답 없음]"
+    except Exception as e:
+        logger.error(f"Error during Gemini API call for text '{japanese_text}': {e}", exc_info=True)
+        return "[번역 오류 발생]"
 
 # --- Kafka Producer 초기화 ---
 # Producer는 비교적 가벼우므로 요청 시 생성하거나, 앱 시작 시 생성 가능
@@ -85,84 +152,150 @@ consumer = None # Consumer 객체를 전역 또는 클래스 멤버로 관리
 def _run_kafka_consumer_loop(consumer: KafkaConsumer, main_loop: asyncio.AbstractEventLoop):
     """
     백그라운드 스레드에서 실행될 Kafka Consumer 루프.
-    메인 asyncio 루프 객체를 인자로 받아 WebSocket 통신에 사용합니다.
+    STT 결과를 받아 Gemini로 번역 후 WebSocket 통신 및 Redis 저장을 수행합니다.
     """
-    # 스레드 내에서 필요한 클라이언트 등 얻기 (Redis 예시)
     redis_client = get_redis_client()
     logger.info("Kafka Consumer thread started. Waiting for messages from topic '{}'...".format(STT_RESULT_TOPIC))
 
     try:
-        # 동기 Consumer 루프
-        for message in consumer:
-            # 앱 종료 신호 확인
+        for message in consumer: # Kafka 메시지 수신 루프
             if stop_consumer_event.is_set():
-                logger.info("Stop event received, exiting consumer loop.")
+                logger.info("Stop event received by Kafka consumer thread, exiting loop.")
                 break
 
-            # --- 테스트용 로그 ---
             logger.info(f"!!!!!!!!!! [Thread] Message Received from Kafka: {message.topic}/{message.partition}/{message.offset}: key={message.key} !!!!!!!!!!")
 
             try:
-                result_data = message.value # value_deserializer가 이미 dict로 변환했을 것
-                logger.debug(f"[Thread] Message Value (raw): {result_data}")
+                result_data = message.value # JSON 역직렬화된 dict (KafkaConsumer 설정에 따름)
                 task_id = result_data.get('task_id')
 
-                if task_id:
-                    logger.info(f"[Thread] Received result/update for task {task_id}, Status: {result_data.get('status')}")
-
-                    # 1. WebSocket으로 실시간 전송 (메인 루프 사용)
-                    if main_loop and main_loop.is_running():
-                        logger.debug(f"[Thread] Scheduling WS send for task {task_id} on main loop...")
-                        # _send_ws_update_async 코루틴을 메인 루프에서 실행하도록 예약
-                        future = asyncio.run_coroutine_threadsafe(
-                            _send_ws_update_async( # 이 함수는 async def 여야 함
-                                task_id,
-                                result_data.get("status", "UNKNOWN"),
-                                result_data.get("progress"),
-                                result_data.get("data"),
-                                result_data.get("error")
-                            ),
-                            main_loop # 전달받은 메인 루프 사용
-                        )
-                        # 선택 사항: 전송 결과 확인 (블로킹 주의)
-                        # try:
-                        #     future.result(timeout=5) # 예: 5초 타임아웃
-                        #     logger.debug(f"[Thread] WS send scheduled successfully for task {task_id}.")
-                        # except TimeoutError:
-                        #      logger.warning(f"[Thread] Timeout waiting for WS send result for task {task_id}.")
-                        # except Exception as e:
-                        #      logger.error(f"[Thread] Exception during WS send scheduling/execution for task {task_id}: {e}")
-
-                    else:
-                         logger.warning(f"[Thread] Main event loop not running or not available for task {task_id}. Skipping WS send.")
-
-                    # 2. Redis에 메시지 히스토리 저장 (동기 작업)
-                    if redis_client:
-                        try:
-                            redis_key = f"ws_messages:{task_id}"
-                            message_json = json.dumps(result_data)
-                            redis_client.rpush(redis_key, message_json)
-                            # TTL은 매번 설정해도 되지만, 처음 또는 주기적으로 설정하는 것이 더 효율적일 수 있음
-                            redis_client.expire(redis_key, get_message_ttl())
-                            logger.debug(f"[Thread] Saved WS message to Redis list {redis_key}")
-                        except Exception as e:
-                            logger.error(f"[Thread] Failed to save message to Redis for {task_id}: {e}", exc_info=True)
-                else:
+                if not task_id:
                     logger.warning(f"[Thread] Received message without task_id: {result_data}")
+                    continue # task_id 없으면 다음 메시지로
 
-            except json.JSONDecodeError:
-                 logger.error(f"[Thread] Failed to decode message value: {message.value}")
-            except Exception as e:
-                # 개별 메시지 처리 오류 로깅 (루프는 계속 진행)
-                logger.error(f"[Thread] Error processing message: {e}", exc_info=True)
+                logger.info(f"[Thread][Task {task_id}] Received Kafka message, Status: {result_data.get('status')}, Progress: {result_data.get('progress')}")
+                logger.debug(f"[Thread][Task {task_id}] Raw message data: {result_data.get('data')}")
 
-    except Exception as e:
-        # Consumer 루프 자체의 예외 (연결 끊김 등)
-        logger.error(f"Unexpected error in Kafka Consumer loop: {e}", exc_info=True)
+                # --- STT 세그먼트 데이터가 있고, 번역이 필요한 경우 ---
+                # result_data["data"]가 리스트이고, 그 안에 "text" 키를 가진 딕셔너리들이 있다면 STT 결과로 간주
+                is_stt_segment_data = (
+                    result_data.get("data")
+                    and isinstance(result_data["data"], list)
+                    and len(result_data["data"]) > 0
+                    and isinstance(result_data["data"][0], dict)
+                    and "text" in result_data["data"][0] # 첫 번째 요소에 text 필드 확인
+                )
+
+                if is_stt_segment_data:
+                    stt_segments = result_data["data"]
+                    logger.info(f"[Thread][Task {task_id}] Found {len(stt_segments)} STT segments. Proceeding to translate with Gemini.")
+
+                    # --- 비동기 번역 작업을 위한 헬퍼 함수 ---
+                    async def _translate_batch_async(segments_to_translate):
+                        translation_coroutines = []
+                        for seg_idx, segment_content in enumerate(segments_to_translate):
+                            jp_text = segment_content.get("text")
+                            if jp_text and isinstance(jp_text, str): # 실제 텍스트가 있는지 확인
+                                logger.debug(f"[Thread][Task {task_id}][Seg {seg_idx+1}] Scheduling translation for: '{jp_text}'")
+                                translation_coroutines.append(translate_japanese_to_korean_with_gemini(jp_text))
+                            else:
+                                # 번역할 일본어 텍스트가 없는 경우 (예: 빈 문자열, None)
+                                logger.debug(f"[Thread][Task {task_id}][Seg {seg_idx+1}] No Japanese text to translate, skipping Gemini call.")
+                                translation_coroutines.append(asyncio.sleep(0, result="[원본 텍스트 없음 또는 부적절]")) # 즉시 완료, 플레이스홀더 반환
+                        
+                        # 모든 번역 작업을 동시에 실행하고 결과 수집 (개별 작업 오류도 반환)
+                        return await asyncio.gather(*translation_coroutines, return_exceptions=True)
+                    # --- 비동기 번역 헬퍼 함수 끝 ---
+
+                    # 메인 이벤트 루프에서 번역 작업들 실행 및 결과 대기
+                    if main_loop and main_loop.is_running() and gemini_translation_model: # Gemini 모델 초기화 확인
+                        future = asyncio.run_coroutine_threadsafe(_translate_batch_async(stt_segments), main_loop)
+                        try:
+                            # 번역 작업 타임아웃 설정 (넉넉하게, 세그먼트 수에 따라 조절)
+                            # 예: 기본 30초 + (세그먼트당 평균 5초 * 세그먼트 수)
+                            timeout_seconds = 30 + (len(stt_segments) * 5) 
+                            logger.debug(f"[Thread][Task {task_id}] Waiting for {len(stt_segments)} translations with timeout {timeout_seconds}s...")
+                            translated_texts_or_errors_list = future.result(timeout=timeout_seconds)
+                            logger.info(f"[Thread][Task {task_id}] Gemini translation batch completed.")
+
+                            # 번역 결과를 원본 세그먼트에 'korean_text' 키로 추가
+                            for i, segment in enumerate(stt_segments):
+                                original_jp_text = segment.get("text", "[원본 JP 없음]") # 로깅용
+                                if i < len(translated_texts_or_errors_list):
+                                    translation_result = translated_texts_or_errors_list[i]
+                                    if isinstance(translation_result, Exception):
+                                        # 개별 번역 작업에서 예외 발생 시
+                                        logger.error(f"[Thread][Task {task_id}][Seg {i+1}] Translation failed for '{original_jp_text}': {translation_result}")
+                                        segment["korean_text"] = "[번역 중 오류 발생]"
+                                    elif translation_result is None:
+                                        # translate_japanese_to_korean_with_gemini 가 None 반환 시 (API 키 없음 등)
+                                        logger.warning(f"[Thread][Task {task_id}][Seg {i+1}] Translation for '{original_jp_text}' returned None.")
+                                        segment["korean_text"] = "[번역 결과 없음]"
+                                    else:
+                                        segment["korean_text"] = str(translation_result) # 문자열로 확실히 변환
+                                        # --- 번역된 한국어 내용 로그로 바로 확인 ---
+                                        logger.info(f"[Thread][Task {task_id}][Seg {i+1}] JP: '{original_jp_text}'  ==>  KO: '{segment['korean_text']}'")
+                                else:
+                                    logger.warning(f"[Thread][Task {task_id}][Seg {i+1}] Translation result missing for '{original_jp_text}'.")
+                                    segment["korean_text"] = "[번역 누락]"
+                        except asyncio.TimeoutError:
+                            logger.error(f"[Thread][Task {task_id}] Gemini translation for segments timed out after {timeout_seconds}s.")
+                            for segment in stt_segments: segment["korean_text"] = "[번역 시간 초과]"
+                        except Exception as e_trans_batch:
+                            logger.error(f"[Thread][Task {task_id}] An error occurred during batch Gemini translation execution: {e_trans_batch}", exc_info=True)
+                            for segment in stt_segments: segment["korean_text"] = "[번역 시스템 오류]"
+                    elif not gemini_translation_model:
+                        logger.warning(f"[Thread][Task {task_id}] Gemini model not initialized. Skipping all translations.")
+                        for segment in stt_segments: segment["korean_text"] = "[번역 건너뜀 - 모델 미초기화]"
+                    else: # main_loop 없거나 실행 중 아닐 때
+                        logger.warning(f"[Thread][Task {task_id}] Main event loop not available. Skipping all translations.")
+                        for segment in stt_segments: segment["korean_text"] = "[번역 건너뜀 - 루프 없음]"
+                    
+                    result_data["data"] = stt_segments # 번역된 텍스트가 포함된 세그먼트로 업데이트
+                # --- STT 세그먼트 번역 처리 끝 ---
+
+                # WebSocket으로 업데이트된 result_data 전송 및 Redis 저장
+                if main_loop and main_loop.is_running():
+                    logger.debug(f"[Thread][Task {task_id}] Scheduling WebSocket send and Redis save.")
+                    asyncio.run_coroutine_threadsafe(
+                        _send_ws_update_async(
+                            task_id,
+                            result_data.get("status", "UNKNOWN"),
+                            result_data.get("progress"),
+                            result_data.get("data"), # 이제 여기에 korean_text 포함됨
+                            result_data.get("error")
+                        ),
+                        main_loop
+                    )
+                else:
+                    logger.warning(f"[Thread][Task {task_id}] Main event loop not available for WebSocket/Redis update.")
+                
+                # Redis 저장 (동기적, 에러 핸들링 추가)
+                if redis_client:
+                    try:
+                        redis_key = f"ws_messages:{task_id}"
+                        # result_data가 dict인지 확인 (value_deserializer에 의해 이미 dict여야 함)
+                        message_to_store = result_data if isinstance(result_data, dict) else {"error": "Invalid data format for Redis"}
+                        message_json = json.dumps(message_to_store) # 이제 korean_text 포함
+                        redis_client.rpush(redis_key, message_json)
+                        redis_client.expire(redis_key, get_message_ttl())
+                        logger.debug(f"[Thread][Task {task_id}] Saved updated message to Redis list {redis_key}")
+                    except Exception as e_redis:
+                        logger.error(f"[Thread][Task {task_id}] Failed to save message to Redis: {e_redis}", exc_info=True)
+
+            except json.JSONDecodeError as e_json_decode:
+                 logger.error(f"[Thread] Failed to decode Kafka message value: {message.value}. Error: {e_json_decode}", exc_info=True)
+            except Exception as e_msg_proc:
+                logger.error(f"[Thread][Task {task_id if 'task_id' in locals() else 'Unknown'}] Error processing Kafka message: {e_msg_proc}", exc_info=True)
+
+    except KeyboardInterrupt: # Ctrl+C 등으로 스레드 종료 시
+        logger.info("Kafka Consumer thread received KeyboardInterrupt. Exiting...")
+    except Exception as e_consumer_loop:
+        logger.error(f"Fatal error in Kafka Consumer loop: {e_consumer_loop}", exc_info=True)
     finally:
-        # 스레드 종료 시 Consumer 반드시 닫기
         logger.info("Closing Kafka Consumer in thread.")
-        consumer.close()
+        if consumer: # consumer 객체가 None이 아닐 때만 close 호출
+            consumer.close()
 
 # --- 앱 시작 시 Kafka Consumer 스레드 실행 ---
 @app.on_event("startup")

--- a/frontend/src/pages/TranslateResult.js
+++ b/frontend/src/pages/TranslateResult.js
@@ -401,14 +401,96 @@ const TranslateResult = () => {
         const ws = new WebSocket(`${process.env.REACT_APP_WS_BASE_URL}/ws/${taskId}`);
         socketRef.current = ws;
 
+        // ws.onmessage = (event) => {
+        //   const msg = JSON.parse(event.data);
+        //   if (msg.data && Array.isArray(msg.data)) {
+        //     setSegments(prev => [...prev, ...msg.data]);
+        //   }
+        //   if (msg.progress !== undefined) setProgress(msg.progress);
+        //   if (msg.status) setStatus(msg.status);
+        //   if (msg.status === 'COMPLETED') setLoading(false);
+        // };
+
+        // TranslateResult.js - useEffect 내 ws.onmessage 수정 (개선안)
+
         ws.onmessage = (event) => {
           const msg = JSON.parse(event.data);
-          if (msg.data && Array.isArray(msg.data)) {
-            setSegments(prev => [...prev, ...msg.data]);
-          }
-          if (msg.progress !== undefined) setProgress(msg.progress);
+          console.log("WebSocket Message Received:", msg);
+
           if (msg.status) setStatus(msg.status);
-          if (msg.status === 'COMPLETED') setLoading(false);
+          if (msg.progress !== undefined) setProgress(msg.progress);
+
+          if (msg.data && Array.isArray(msg.data)) {
+            if (msg.status === 'COMPLETED') {
+              // 최종 "COMPLETED" 메시지 수신: 기존 세그먼트에 한국어 번역 업데이트
+              setSegments(prevSegments => {
+                // 새로운 번역 데이터를 Map으로 만들어 빠르게 조회 (key: start-end)
+                const translatedDataMap = new Map(
+                  msg.data.map(translatedSeg => [`${translatedSeg.start}-${translatedSeg.end}`, translatedSeg])
+                );
+
+                // 기존 세그먼트 배열을 순회하며, 번역된 텍스트로 업데이트
+                const updatedSegments = prevSegments.map(existingSeg => {
+                  const key = `${existingSeg.start}-${existingSeg.end}`;
+                  const translatedSegData = translatedDataMap.get(key);
+
+                  if (translatedSegData && translatedSegData.korean_text) {
+                    // 기존 세그먼트 객체에 korean_text 필드를 추가/업데이트하여 새 객체 반환
+                    // 이렇게 하면 React가 변경을 감지하고 해당 세그먼트만 효율적으로 업데이트
+                    return { ...existingSeg, korean_text: translatedSegData.korean_text };
+                  }
+                  // 번역 데이터가 없거나 korean_text가 없으면 기존 세그먼트 유지
+                  return existingSeg;
+                });
+                
+                // 만약 COMPLETED 메시지의 msg.data가 항상 모든 세그먼트를 포함하고,
+                // 이전 PROCESSING 메시지의 세그먼트와 정확히 일치한다면 (순서나 개수가 다를 수 있음),
+                // 아래와 같이 msg.data를 기준으로 prevSegments를 업데이트할 수도 있습니다.
+                // 이는 msg.data가 최종적이고 완전한 상태라고 가정합니다.
+                /*
+                const finalSegments = msg.data.map(finalSeg => {
+                    const key = `${finalSeg.start}-${finalSeg.end}`;
+                    const existingSegment = prevSegments.find(pSeg => `${pSeg.start}-${pSeg.end}` === key);
+                    // 기존 정보(예: active 상태 등 프론트엔드 전용 상태)가 있다면 유지하고,
+                    // 서버에서 온 데이터(text, korean_text)로 덮어쓰기
+                    return { ...(existingSegment || {}), ...finalSeg };
+                });
+                return finalSegments.sort((a,b) => a.start - b.start);
+                */
+              // 위 예시 중 첫번째(prevSegments.map) 방식이 더 '업데이트'에 가깝습니다.
+                return updatedSegments.sort((a,b) => a.start - b.start);
+              });
+              setLoading(false);
+              console.log("Segments updated with translations:", msg.data);
+
+            } else if (msg.status === 'PROCESSING' || msg.status === 'STT_COMPLETED_ALL_SEGMENTS') {
+              // 중간 STT 결과 (일본어만) 또는 STT 전체 완료 (번역 전)
+              setSegments(prevSegments => {
+                const newSegmentsMap = new Map(prevSegments.map(s => [`${s.start}-${s.end}`, s]));
+                msg.data.forEach(newSeg => {
+                  const key = `${newSeg.start}-${newSeg.end}`;
+                  // 기존에 없던 세그먼트이거나, 기존 세그먼트에 korean_text가 아직 없는데 새로운 데이터에 text만 있다면 추가/업데이트
+                  // (korean_text가 있는 최종 데이터는 COMPLETED에서 처리)
+                  if (!newSegmentsMap.has(key) || !newSegmentsMap.get(key).korean_text) {
+                    newSegmentsMap.set(key, { ...newSegmentsMap.get(key), ...newSeg }); // 기존 정보에 새 정보 병합
+                  }
+                });
+                return Array.from(newSegmentsMap.values()).sort((a, b) => a.start - b.start);
+              });
+              console.log("Intermediate STT segments (JP only) updated/added.");
+            }
+          } else if (msg.data && msg.data.message) {
+            console.log("Status message from backend:", msg.data.message);
+          }
+
+          if (msg.status === 'COMPLETED' || msg.status === 'FAILED' || msg.status?.includes('FAILED')) {
+            setLoading(false);
+            if (socketRef.current) {
+                socketRef.current.close();
+                socketRef.current = null;
+                console.log("WebSocket closed by client on task completion/failure.");
+            }
+          }
         };
 
         ws.onerror = () => {
@@ -489,20 +571,39 @@ const TranslateResult = () => {
             ) : (
               segments.map((seg) => {
                 const isActive = activeIndex === seg.start;
+                // key 값을 좀 더 안정적으로, 예를 들어 start와 end 시간 조합 또는 고유 ID가 있다면 그것 사용
+                const segmentKey = `${seg.start}-${seg.end}-${seg.text?.slice(0,5)}`; // 예시
+              
                 return (
                   <div
-                    key={seg.start}
-                    id={`segment-${seg.start}`}
+                    key={segmentKey} // 수정된 key 사용
+                    id={`segment-${segmentKey}`} // id도 key와 일치시키는 것이 좋음
                     onClick={() => playerRef.current?.seekTo(seg.start, 'seconds')}
-                    className={`p-3 my-2 rounded-md text-sm transition-all duration-300 border cursor-pointer ${isActive
-                        ? 'bg-white text-blue-700 font-bold shadow-lg scale-[1.03]'
+                    className={`p-3 my-2 rounded-md text-sm transition-all duration-300 border cursor-pointer ${
+                      isActive
+                        ? 'bg-white text-blue-700 font-bold shadow-lg scale-[1.03]' // 기존 활성 스타일
                         : 'bg-gray-700 text-white/90 hover:bg-gray-600 border-transparent'
-                      }`}
+                    }`}
                   >
                     <div className="text-xs text-blue-300 font-mono mb-1">
                       [{formatTimestamp(seg.start)} - {formatTimestamp(seg.end)}]
                     </div>
-                    <div>{seg.text}</div>
+                    {/* 일본어 텍스트 */}
+                    <div className="mb-1"> {/* 일본어 텍스트와 한국어 텍스트 사이에 간격을 주기 위해 mb-1 추가 */}
+                      <strong className="text-sky-400">JP:</strong> {seg.text}
+                    </div>
+                    {/* 한국어 번역 텍스트 (korean_text 필드가 있고, 내용이 있고, 플레이스홀더가 아닐 때만 표시) */}
+                    {seg.korean_text && seg.korean_text.trim() !== "" && !seg.korean_text.startsWith("[") && (
+                      <div className="text-green-400"> {/* 한국어 텍스트 스타일 */}
+                        <strong className="text-green-300">KO:</strong> {seg.korean_text}
+                      </div>
+                    )}
+                    {/* (선택적) 번역 오류 또는 플레이스홀더 메시지 처리 */}
+                    {seg.korean_text && seg.korean_text.startsWith("[") && (
+                         <div className="text-xs text-yellow-500 italic mt-1"> {/* 오류/플레이스홀더 스타일 */}
+                             KO: {seg.korean_text}
+                         </div>
+                    )}
                   </div>
                 );
               })


### PR DESCRIPTION
# ✨ 비동기 STT 처리 및 Gemini 일괄 번역 파이프라인 구축 (Kafka + WebSocket)

## 📝 개요 (Overview)

본 PR은 기존 동기식 처리 시스템의 한계점(긴 작업 시간 동안 사용자 대기, UI 멈춤, 서버 타임아웃)을 해결하기 위해, **Apache Kafka를 메시지 브로커로 사용하는 완전한 비동기 처리 파이프라인**을 구축합니다.  
또한, WebSocket을 통해 **실시간으로 STT 진행 상황 및 Gemini API를 통한 한국어 번역 결과까지 보여주는 React 프론트엔드**를 구현합니다.

---

## 🚀 주요 변경 내용 (Key Changes)

### Backend

#### ✅ Kafka 기반 비동기 STT 파이프라인 구축

- **API 서버 (stt-processor-api)** 와 **STT 워커 (stt-processor-worker)** 를 **Decoupling**.
- **Kafka 토픽 정의**:
  - `stt_requests`: STT 요청 정보 발행
  - `stt_results`: STT 처리 결과 및 상태 발행

#### ✅ STT 워커 (Kafka Consumer - `stt-processor-worker`)

- `consumer.py` 통해 `stt_requests` 구독
- 오디오 파일을 청크 단위로 분할 (pydub)
- 각 청크별 STT 수행 (faster-whisper)
- 결과를 PROCESSING 상태로 `stt_results` 발행
- 모든 청크 완료 시 `STT_COMPLETED_ALL_SEGMENTS` 메시지 발행
- **Kafka Producer 재시도 로직 추가**

#### ✅ API 서버 (Kafka Producer/Consumer + WebSocket + Gemini API)

- `POST /request_transcription`: STT 요청 (기존 유지)
- `GET /ws/{task_id}`: WebSocket 연결
- 백그라운드 Kafka Consumer:
  - `PROCESSING`: 실시간 STT 결과 WebSocket 전달
  - `STT_COMPLETED_ALL_SEGMENTS`:
    - 일본어 세그먼트를 Gemini API로 일괄 번역
    - 프롬프트 엔지니어링 (구분자/번호 유지)
    - 결과를 WebSocket으로 `status: COMPLETED`와 함께 전송
- 세그먼트 수 불일치 시 Fallback 처리

#### ✅ 기타 개선

- Redis 메시지 히스토리 저장 (기존 유지)
- 환경변수 `.env` → `.env.example` 제공
- Python 3.9 호환을 위한 타입 힌트 수정 (`Union`)
- 안정성 강화 코드 추가

---

### Frontend (`stt-client`)

- React 앱 신규 생성
- WebSocket 연결 및 상태 업데이트 구현
  - `PROCESSING`: 일본어 텍스트 실시간 렌더링
  - `COMPLETED`: 번역된 한국어 텍스트 추가 렌더링
- UI 최적화 (불필요한 리렌더링 최소화)
- `.env` 파일로 API 주소 관리

---

## 🤔 기술 선택 이유 (Rationale)

### Kafka
- 높은 확장성과 비동기 이벤트 처리 능력

### WebSocket
- 실시간 사용자 피드백 제공

### Redis
- 메시지 히스토리 저장

### Gemini API
- 구어체 번역에 강함
- 번역 스타일 제어 가능 (프롬프트 엔지니어링)
- 일괄 번역 지원 → LLM의 문맥 인지 활용 가능

---

## 💡 어려움 극복 과정 (Challenges & Solutions)

| 문제 | 해결 방법 |
|------|-----------|
| Kafka 연결 오류 | 재시도 로직 추가 |
| 백엔드 Consumer 오류 | 별도 스레드 관리 및 예외 처리 |
| Gemini 번역 시 세그먼트 수 불일치 | 프롬프트 개선 및 Fallback 처리 (개별 번역) |
| Python 3.9 호환성 문제 | `Union` 타입 힌트로 수정 |
| CORS 문제 | 기존 방식 유지 |

---

## 🔌 사용된 API 엔드포인트 요약

### ▶ `POST /extract` (youtube-extractor @ 8000)
- YouTube 오디오 추출

### ▶ `POST /request_transcription` (stt-processor-api @ 8001)
- STT 요청

### ▶ `GET /ws/{task_id}` (stt-processor-api @ 8001)
- WebSocket STT 상태 수신

#### 📦 WebSocket 메시지 포맷 예시

##### 진행 중
```json
{
  "status": "PROCESSING",
  "progress": 50,
  "data": [{"start": 10.1, "end": 15.5, "text": "日本のテキスト..."}]
}
```
##### STT 완료 (번역 전)
```json
{
  "status": "STT_COMPLETED_ALL_SEGMENTS",
  "progress": 95,
  "data": [
    {"start": 10.1, "end": 15.5, "text": "日本のテキスト1..."},
    {"start": 16.0, "end": 20.2, "text": "日本のテキスト2..."}
  ]
}
```
##### 최종 완료 (번역 포함)
```json
{
  "status": "COMPLETED",
  "progress": 100,
  "data": [
    {"start": 10.1, "end": 15.5, "text": "日本のテキスト1...", "korean_text": "한국어 번역1..."},
    {"start": 16.0, "end": 20.2, "text": "日本のテキスト2...", "korean_text": "한국어 번역2..."}
  ]
}
```
##### 실패
```json
{
  "status": "FAILED",
  "error": "Error message details..."
}
```
---

## ✅ 테스트 방법 (How to Test)
1. 환경 변수 설정
- backend/.env.example 참고하여 .env 생성
- GEMINI_API_KEY="YOUR_API_KEY" 입력
2. 백엔드 실행

```bash
docker-compose down -v
docker-compose up -d --build
```

3. 프론트엔드 개발 서버 실행
- 기존 방식 유지

4. STT 요청 테스트
- 요청 → WebSocket 메시지 수신 → UI 반영 확인

5. 결과 확인
- 실시간 진행률 & 상태 표시
- 최종 결과로 일본어 + 한국어 텍스트 표시

6. 필요시 로그 확인
- docker logs <container> 등

---